### PR TITLE
fix: changed title to better reflect intent

### DIFF
--- a/pt_BR.md
+++ b/pt_BR.md
@@ -1,6 +1,6 @@
-# O Código de Ética de Designers
+# O Código de Ética para Designers
 
-- [O Código de Ética de Designers](#o-c%c3%b3digo-de-%c3%89tica-de-designers)
+- [O Código de Ética para Designers](#o-c%c3%b3digo-de-%c3%89tica-para-designers)
     - [Designers são antes de tudo e principalmente seres humanos.](#designers-s%c3%a3o-antes-de-tudo-e-principalmente-seres-humanos)
     - [Designers são responsáveis pelo trabalho que colocam no mundo.](#designers-s%c3%a3o-respons%c3%a1veis-pelo-trabalho-que-colocam-no-mundo)
     - [Designers valorizam impacto sobre a forma.](#designers-valorizam-impacto-sobre-a-forma)


### PR DESCRIPTION
Changing the title to "O Código de Ética para Designers".

We decided to use "Designers" in our translation since in Portuguese, "A Designer" would be translated as "Um designer", which is a gendered noun. Use used "Designers" to be gender neutral, in this way this decision affected the whole text in propositions, etc. And in order to the title 'sound better', we agreed upon on make this fix from "O Código de Ética de Designers" to "O Código de Ética para Designers", to better reflect this editorial choice in our side.

Thanks!